### PR TITLE
98 responsiveness fix

### DIFF
--- a/src/components/Layout/CardBase.tsx
+++ b/src/components/Layout/CardBase.tsx
@@ -9,10 +9,10 @@ export const CardBase: React.FC = ({ children }) => {
         <Box
             as='article'
             overflow='auto'
-            h='100%'
+            h='fit-content'
             minH='432px'
-            w='100%'
-            maxW={[`${width - stylesPaddingTotal}px`, '550px', '550px']}
+            w='100vw'
+            maxW={[`${width - stylesPaddingTotal}px`, '555px', '555px']}
             borderWidth={1}
             borderRadius='31px'
             bg='interactive.gray.13'

--- a/src/components/Layout/CardBase.tsx
+++ b/src/components/Layout/CardBase.tsx
@@ -1,0 +1,24 @@
+import { Box } from '@chakra-ui/react'
+import { useWindowSize } from '../utils/useWindowSize'
+
+export const CardBase: React.FC = ({ children }) => {
+    const { width } = useWindowSize()
+    const stylesPaddingTotal = 19 * 2 // 19px on each side
+
+    return (
+        <Box
+            as='article'
+            overflow='scroll'
+            h='100%'
+            minH='432px'
+            w='100%'
+            maxW={[`${width - stylesPaddingTotal}px`, '550px', '550px']}
+            borderWidth={1}
+            borderRadius='31px'
+            bg='interactive.gray.13'
+            color='interactive.white'
+        >
+            {children && children}
+        </Box>
+    )
+}

--- a/src/components/Layout/CardBase.tsx
+++ b/src/components/Layout/CardBase.tsx
@@ -17,6 +17,7 @@ export const CardBase: React.FC = ({ children }) => {
             borderRadius='31px'
             bg='interactive.gray.13'
             color='interactive.white'
+            m='0px !important'
             p={[4, 4, 8]}
         >
             {children && children}

--- a/src/components/Layout/CardBase.tsx
+++ b/src/components/Layout/CardBase.tsx
@@ -8,7 +8,7 @@ export const CardBase: React.FC = ({ children }) => {
     return (
         <Box
             as='article'
-            overflow='scroll'
+            overflow='auto'
             h='100%'
             minH='432px'
             w='100%'
@@ -17,6 +17,7 @@ export const CardBase: React.FC = ({ children }) => {
             borderRadius='31px'
             bg='interactive.gray.13'
             color='interactive.white'
+            p={[4, 4, 8]}
         >
             {children && children}
         </Box>

--- a/src/components/Layout/VStackBase.tsx
+++ b/src/components/Layout/VStackBase.tsx
@@ -6,7 +6,7 @@ export const VStackBase: React.FC = ({ children }) => (
         h='fit-content'
         overflow='hidden'
         flex='1'
-        py='80px'
+        py={['0px', '0px', '80px']}
         justifyContent={['flex-start', 'flex-start', 'flex-start']}
     >
         {children}

--- a/src/components/Layout/VStackBase.tsx
+++ b/src/components/Layout/VStackBase.tsx
@@ -1,0 +1,14 @@
+import { VStack } from '@chakra-ui/react'
+
+export const VStackBase: React.FC = ({ children }) => (
+    <VStack
+        maxHeight='662px'
+        h='fit-content'
+        overflow='hidden'
+        flex='1'
+        py='80px'
+        justifyContent={['flex-start', 'flex-start', 'flex-start']}
+    >
+        {children}
+    </VStack>
+)

--- a/src/components/Layout/VStackBase.tsx
+++ b/src/components/Layout/VStackBase.tsx
@@ -2,7 +2,8 @@ import { VStack } from '@chakra-ui/react'
 
 export const VStackBase: React.FC = ({ children }) => (
     <VStack
-        maxHeight='662px'
+        maxHeight='960px'
+        m={0}
         h='fit-content'
         overflow='hidden'
         flex='1'

--- a/src/components/NavbarMobile.tsx
+++ b/src/components/NavbarMobile.tsx
@@ -14,7 +14,7 @@ export default function NavbarMobile() {
             <Box
                 bg='#101010'
                 h='92px'
-                position='absolute'
+                position='sticky'
                 bottom={0}
                 w='100%'
                 borderRadius='30px 30px 0px 0px'

--- a/src/components/Stability/ActiveDeposit.tsx
+++ b/src/components/Stability/ActiveDeposit.tsx
@@ -15,6 +15,7 @@ import { useStabilityView } from './context/StabilityViewContext'
 import { RemainingLQTY } from './RemainingLQTY'
 import { Yield } from './Yield'
 import { InfoIcon } from '../InfoIcon'
+import { CardBase } from 'components/Layout/CardBase'
 
 const selector = ({
     stabilityDeposit,
@@ -57,7 +58,7 @@ export const ActiveDeposit: React.FC = () => {
     }, [transactionState.type, dispatchEvent])
 
     return (
-        <Box maxW='sm' borderWidth='1px' borderRadius='lg' overflow='hidden'>
+        <CardBase>
             <Heading>
                 Stability Pool
                 {!isWaitingForTransaction && (
@@ -154,6 +155,6 @@ export const ActiveDeposit: React.FC = () => {
             </Box>
 
             {isWaitingForTransaction && <LoadingOverlay />}
-        </Box>
+        </CardBase>
     )
 }

--- a/src/components/Stability/NoDeposit.tsx
+++ b/src/components/Stability/NoDeposit.tsx
@@ -4,6 +4,7 @@ import { InfoMessage } from '../InfoMessage'
 import { useStabilityView } from './context/StabilityViewContext'
 import { RemainingLQTY } from './RemainingLQTY'
 import { Yield } from './Yield'
+import { CardBase } from 'components/Layout/CardBase'
 
 export const NoDeposit: React.FC = () => {
     const { dispatchEvent } = useStabilityView()
@@ -13,47 +14,31 @@ export const NoDeposit: React.FC = () => {
     }, [dispatchEvent])
 
     return (
-        <Flex
-            w='555px'
-            height='432px'
-            alignItems='center'
-            justifyContent='center'
-        >
-            <Box
-                w='100%'
-                h='100%'
-                maxW='md'
-                borderWidth={1}
-                borderRadius='31px'
-                overflow='hidden'
-                bg='#131313'
-                color='#FFFFFF'
-            >
-                <Heading>
-                    Stability Pool
-                    <Flex sx={{ justifyContent: 'flex-end' }}>
-                        <RemainingLQTY />
-                    </Flex>
-                </Heading>
-                <Box sx={{ p: [2, 3] }}>
-                    <InfoMessage title='You have no LUSD in the Stability Pool.'>
-                        You can earn ETH and LQTY rewards by depositing LUSD.
-                    </InfoMessage>
+        <CardBase>
+            <Heading>
+                Stability Pool
+                <Flex sx={{ justifyContent: 'flex-end' }}>
+                    <RemainingLQTY />
+                </Flex>
+            </Heading>
+            <Box sx={{ p: [2, 3] }}>
+                <InfoMessage title='You have no LUSD in the Stability Pool.'>
+                    You can earn ETH and LQTY rewards by depositing LUSD.
+                </InfoMessage>
 
-                    <Flex variant='layout.actions'>
-                        <Flex
-                            sx={{
-                                justifyContent: 'flex-start',
-                                flex: 1,
-                                alignItems: 'center',
-                            }}
-                        >
-                            <Yield />
-                        </Flex>
-                        <Button onClick={handleOpenTrove}>Deposit</Button>
+                <Flex variant='layout.actions'>
+                    <Flex
+                        sx={{
+                            justifyContent: 'flex-start',
+                            flex: 1,
+                            alignItems: 'center',
+                        }}
+                    >
+                        <Yield />
                     </Flex>
-                </Box>
+                    <Button onClick={handleOpenTrove}>Deposit</Button>
+                </Flex>
             </Box>
-        </Flex>
+        </CardBase>
     )
 }

--- a/src/components/Stability/StabilityDepositEditor.tsx
+++ b/src/components/Stability/StabilityDepositEditor.tsx
@@ -17,6 +17,7 @@ import { Icon } from '../Icon'
 import { EditableRow, StaticRow } from '../Trove/Editor'
 import { LoadingOverlay } from '../LoadingOverlay'
 import { InfoIcon } from '../InfoIcon'
+import { CardBase } from 'components/Layout/CardBase'
 
 const select = ({ lusdBalance, lusdInStabilityPool }: LiquityStoreState) => ({
     lusdBalance,
@@ -63,131 +64,109 @@ export const StabilityDepositEditor: React.FC<StabilityDepositEditorProps> = ({
         Difference.between(newPoolShare, originalPoolShare).nonZero
 
     return (
-        <Flex
-            w='555px'
-            height='622px'
-            alignItems='center'
-            justifyContent='center'
-        >
-            <Box
-                w='100%'
-                h='100%'
-                maxW='md'
-                borderRadius='31px'
-                overflow='hidden'
-                padding={[10, 34, 34, 5]}
-                bg='#131313'
-                color='#FFFFFF'
-            >
-                <Heading>
-                    Stability Pool
-                    {edited && !changePending && (
-                        <Button
-                            variant='titleIcon'
-                            sx={{ ':enabled:hover': { color: 'danger' } }}
-                            onClick={() => dispatch({ type: 'revert' })}
-                        >
-                            <Icon name='history' size='lg' />
-                        </Button>
-                    )}
-                </Heading>
+        <CardBase>
+            <Heading>
+                Stability Pool
+                {edited && !changePending && (
+                    <Button
+                        variant='titleIcon'
+                        sx={{ ':enabled:hover': { color: 'danger' } }}
+                        onClick={() => dispatch({ type: 'revert' })}
+                    >
+                        <Icon name='history' size='lg' />
+                    </Button>
+                )}
+            </Heading>
 
-                <Box sx={{ p: [2, 3] }}>
-                    <EditableRow
-                        label='Deposit'
-                        inputID='deposit-lqty'
-                        amount={editedLUSD.prettify()}
-                        maxAmount={maxAmount.toString()}
-                        maxedOut={maxedOut}
-                        unit={COIN}
-                        {...{ editingState }}
-                        editedAmount={editedLUSD.toString(2)}
-                        setEditedAmount={newValue =>
-                            dispatch({ type: 'setDeposit', newValue })
-                        }
+            <Box sx={{ p: [2, 3] }}>
+                <EditableRow
+                    label='Deposit'
+                    inputID='deposit-lqty'
+                    amount={editedLUSD.prettify()}
+                    maxAmount={maxAmount.toString()}
+                    maxedOut={maxedOut}
+                    unit={COIN}
+                    {...{ editingState }}
+                    editedAmount={editedLUSD.toString(2)}
+                    setEditedAmount={newValue =>
+                        dispatch({ type: 'setDeposit', newValue })
+                    }
+                />
+
+                {newPoolShare.infinite ? (
+                    <StaticRow
+                        label='Pool share'
+                        inputID='deposit-share'
+                        amount='N/A'
                     />
+                ) : (
+                    <StaticRow
+                        label='Pool share'
+                        inputID='deposit-share'
+                        amount={newPoolShare.prettify(4)}
+                        pendingAmount={poolShareChange?.prettify(4).concat('%')}
+                        pendingColor={
+                            poolShareChange?.positive ? 'success' : 'danger'
+                        }
+                        unit='%'
+                    />
+                )}
 
-                    {newPoolShare.infinite ? (
+                {!originalDeposit.isEmpty && (
+                    <>
                         <StaticRow
-                            label='Pool share'
-                            inputID='deposit-share'
-                            amount='N/A'
-                        />
-                    ) : (
-                        <StaticRow
-                            label='Pool share'
-                            inputID='deposit-share'
-                            amount={newPoolShare.prettify(4)}
-                            pendingAmount={poolShareChange
-                                ?.prettify(4)
-                                .concat('%')}
-                            pendingColor={
-                                poolShareChange?.positive ? 'success' : 'danger'
+                            label='Liquidation gain'
+                            inputID='deposit-gain'
+                            amount={originalDeposit.collateralGain.prettify(4)}
+                            color={
+                                originalDeposit.collateralGain.nonZero &&
+                                'success'
                             }
-                            unit='%'
+                            unit='ETH'
                         />
-                    )}
 
-                    {!originalDeposit.isEmpty && (
-                        <>
-                            <StaticRow
-                                label='Liquidation gain'
-                                inputID='deposit-gain'
-                                amount={originalDeposit.collateralGain.prettify(
-                                    4
-                                )}
-                                color={
-                                    originalDeposit.collateralGain.nonZero &&
-                                    'success'
-                                }
-                                unit='ETH'
-                            />
-
-                            <StaticRow
-                                label='Reward'
-                                inputID='deposit-reward'
-                                amount={originalDeposit.lqtyReward.prettify()}
-                                color={
-                                    originalDeposit.lqtyReward.nonZero &&
-                                    'success'
-                                }
-                                unit={GT}
-                                infoIcon={
-                                    <InfoIcon
-                                        tooltip={
-                                            <Box
-                                                variant='tooltip'
-                                                sx={{
-                                                    padding: '10px',
-                                                    bg: '#a7a7e3',
-                                                    fontSize: '1em',
-                                                    color: '#333',
-                                                    minW: '12.5vw',
-                                                    height: 'auto',
-                                                    maxW: '33vm',
-                                                    fontStyle: 'italic',
-                                                }}
-                                            >
-                                                Although the LQTY rewards accrue
-                                                every minute, the value on the
-                                                UI only updates when a user
-                                                transacts with the Stability
-                                                Pool. Therefore you may receive
-                                                more rewards than is displayed
-                                                when you claim or adjust your
-                                                deposit.
-                                            </Box>
-                                        }
-                                    />
-                                }
-                            />
-                        </>
-                    )}
-                    {children}
-                </Box>
-
-                {changePending && <LoadingOverlay />}
+                        <StaticRow
+                            label='Reward'
+                            inputID='deposit-reward'
+                            amount={originalDeposit.lqtyReward.prettify()}
+                            color={
+                                originalDeposit.lqtyReward.nonZero && 'success'
+                            }
+                            unit={GT}
+                            infoIcon={
+                                <InfoIcon
+                                    tooltip={
+                                        <Box
+                                            variant='tooltip'
+                                            sx={{
+                                                padding: '10px',
+                                                bg: '#a7a7e3',
+                                                fontSize: '1em',
+                                                color: '#333',
+                                                minW: '12.5vw',
+                                                height: 'auto',
+                                                maxW: '33vm',
+                                                fontStyle: 'italic',
+                                            }}
+                                        >
+                                            Although the LQTY rewards accrue
+                                            every minute, the value on the UI
+                                            only updates when a user transacts
+                                            with the Stability Pool. Therefore
+                                            you may receive more rewards than is
+                                            displayed when you claim or adjust
+                                            your deposit.
+                                        </Box>
+                                    }
+                                />
+                            }
+                        />
+                    </>
+                )}
+                {children}
             </Box>
-        </Flex>
+
+            {changePending && <LoadingOverlay />}
+        </CardBase>
     )
 }

--- a/src/components/Staking/NoStake.tsx
+++ b/src/components/Staking/NoStake.tsx
@@ -1,43 +1,27 @@
 import { Heading, Box, Flex, Button } from '@chakra-ui/react'
 import { GT } from '../../strings'
 import { InfoMessage } from '../InfoMessage'
+import { CardBase } from '../Layout/CardBase'
 import { useStakingView } from './context/StakingViewContext'
 
 export const NoStake: React.FC = () => {
     const { dispatch } = useStakingView()
 
     return (
-        <Flex
-            w='555px'
-            height='432px'
-            alignItems='center'
-            justifyContent='center'
-        >
-            <Box
-                w='100%'
-                h='100%'
-                maxW='md'
-                borderWidth={1}
-                borderRadius='31px'
-                overflow='hidden'
-                bg='#131313'
-                color='#FFFFFF'
-            >
-                <Heading>Staking</Heading>
-                <Box sx={{ p: [2, 3] }}>
-                    <InfoMessage title={`You have not staked ${GT} yet.`}>
-                        Stake {GT} to earn a share of borrowing and redemption
-                        fees.
-                    </InfoMessage>
-                    <Flex variant='layout.actions'>
-                        <Button
-                            onClick={() => dispatch({ type: 'startAdjusting' })}
-                        >
-                            Start staking
-                        </Button>
-                    </Flex>
-                </Box>
+        <CardBase>
+            <Heading>Staking</Heading>
+            <Box sx={{ p: [2, 3] }}>
+                <InfoMessage title={`You have not staked ${GT} yet.`}>
+                    Stake {GT} to earn a share of borrowing and redemption fees.
+                </InfoMessage>
+                <Flex variant='layout.actions'>
+                    <Button
+                        onClick={() => dispatch({ type: 'startAdjusting' })}
+                    >
+                        Start staking
+                    </Button>
+                </Flex>
             </Box>
-        </Flex>
+        </CardBase>
     )
 }

--- a/src/components/Staking/ReadOnlyStake.tsx
+++ b/src/components/Staking/ReadOnlyStake.tsx
@@ -7,6 +7,7 @@ import { LoadingOverlay } from '../LoadingOverlay'
 import { Icon } from '../Icon'
 import { useStakingView } from './context/StakingViewContext'
 import { StakingGainsAction } from './StakingGainsAction'
+import { CardBase } from 'components/Layout/CardBase'
 
 const select = ({ lqtyStake, totalStakedLQTY }: LiquityStoreState) => ({
     lqtyStake,
@@ -19,68 +20,52 @@ export const ReadOnlyStake: React.FC = () => {
     const poolShare = lqtyStake.stakedLQTY.mulDiv(100, totalStakedLQTY)
 
     return (
-        <Flex
-            w='555px'
-            minHeight='418px'
-            alignItems='center'
-            justifyContent='center'
-        >
-            <Box
-                w='100%'
-                h='100%'
-                maxW='md'
-                borderRadius='31px'
-                overflow='hidden'
-                padding={[10, 34, 34, 5]}
-                bg='#131313'
-                color='#FFFFFF'
-            >
-                <Heading>Staking</Heading>
-                <Box sx={{ p: [2, 3] }}>
-                    <DisabledEditableRow
-                        label='Stake'
-                        inputID='stake-lqty'
-                        amount={lqtyStake.stakedLQTY.prettify()}
-                        unit={GT}
-                    />
+        <CardBase>
+            <Heading>Staking</Heading>
+            <Box sx={{ p: [2, 3] }}>
+                <DisabledEditableRow
+                    label='Stake'
+                    inputID='stake-lqty'
+                    amount={lqtyStake.stakedLQTY.prettify()}
+                    unit={GT}
+                />
 
-                    <StaticRow
-                        label='Pool share'
-                        inputID='stake-share'
-                        amount={poolShare.prettify(4)}
-                        unit='%'
-                    />
+                <StaticRow
+                    label='Pool share'
+                    inputID='stake-share'
+                    amount={poolShare.prettify(4)}
+                    unit='%'
+                />
 
-                    <StaticRow
-                        label='Redemption gain'
-                        inputID='stake-gain-eth'
-                        amount={lqtyStake.collateralGain.prettify(4)}
-                        color={lqtyStake.collateralGain.nonZero && 'success'}
-                        unit='ETH'
-                    />
+                <StaticRow
+                    label='Redemption gain'
+                    inputID='stake-gain-eth'
+                    amount={lqtyStake.collateralGain.prettify(4)}
+                    color={lqtyStake.collateralGain.nonZero && 'success'}
+                    unit='ETH'
+                />
 
-                    <StaticRow
-                        label='Issuance gain'
-                        inputID='stake-gain-lusd'
-                        amount={lqtyStake.lusdGain.prettify()}
-                        color={lqtyStake.lusdGain.nonZero && 'success'}
-                        unit={COIN}
-                    />
+                <StaticRow
+                    label='Issuance gain'
+                    inputID='stake-gain-lusd'
+                    amount={lqtyStake.lusdGain.prettify()}
+                    color={lqtyStake.lusdGain.nonZero && 'success'}
+                    unit={COIN}
+                />
 
-                    <Flex variant='layout.actions'>
-                        <Button
-                            variant='outline'
-                            onClick={() => dispatch({ type: 'startAdjusting' })}
-                        >
-                            <Icon name='pen' size='sm' />
-                            &nbsp;Adjust
-                        </Button>
+                <Flex variant='layout.actions'>
+                    <Button
+                        variant='outline'
+                        onClick={() => dispatch({ type: 'startAdjusting' })}
+                    >
+                        <Icon name='pen' size='sm' />
+                        &nbsp;Adjust
+                    </Button>
 
-                        <StakingGainsAction />
-                    </Flex>
-                </Box>
-                {changePending && <LoadingOverlay />}
+                    <StakingGainsAction />
+                </Flex>
             </Box>
-        </Flex>
+            {changePending && <LoadingOverlay />}
+        </CardBase>
     )
 }

--- a/src/components/Staking/StakingEditor.tsx
+++ b/src/components/Staking/StakingEditor.tsx
@@ -12,6 +12,7 @@ import { COIN, GT } from '../../strings'
 import { Icon } from '../Icon'
 import { EditableRow, StaticRow } from '../Trove/Editor'
 import { LoadingOverlay } from '../LoadingOverlay'
+import { CardBase } from '../Layout/CardBase'
 import { useStakingView } from './context/StakingViewContext'
 
 const select = ({ lqtyBalance, totalStakedLQTY }: LiquityStoreState) => ({
@@ -54,98 +55,76 @@ export const StakingEditor: React.FC<StakingEditorProps> = ({
         Difference.between(newPoolShare, originalPoolShare).nonZero
 
     return (
-        <Flex
-            w='555px'
-            height='622px'
-            alignItems='center'
-            justifyContent='center'
-        >
-            <Box
-                w='100%'
-                h='100%'
-                maxW='md'
-                borderRadius='31px'
-                overflow='hidden'
-                padding={[10, 34, 34, 5]}
-                bg='#131313'
-                color='#FFFFFF'
-            >
-                <Heading>
-                    {title}
-                    {edited && !changePending && (
-                        <Button
-                            variant='titleIcon'
-                            sx={{ ':enabled:hover': { color: 'danger' } }}
-                            onClick={() => dispatch({ type: 'revert' })}
-                        >
-                            <Icon name='history' size='lg' />
-                        </Button>
-                    )}
-                </Heading>
-                <Box sx={{ p: [2, 3] }}>
-                    <EditableRow
-                        label='Stake'
-                        inputID='stake-lqty'
-                        amount={editedLQTY.prettify()}
-                        maxAmount={maxAmount.toString()}
-                        maxedOut={maxedOut}
-                        unit={GT}
-                        {...{ editingState }}
-                        editedAmount={editedLQTY.toString(2)}
-                        setEditedAmount={newValue =>
-                            dispatch({ type: 'setStake', newValue })
-                        }
+        <CardBase>
+            <Heading>
+                {title}
+                {edited && !changePending && (
+                    <Button
+                        variant='titleIcon'
+                        sx={{ ':enabled:hover': { color: 'danger' } }}
+                        onClick={() => dispatch({ type: 'revert' })}
+                    >
+                        <Icon name='history' size='lg' />
+                    </Button>
+                )}
+            </Heading>
+            <Box sx={{ p: [2, 3] }}>
+                <EditableRow
+                    label='Stake'
+                    inputID='stake-lqty'
+                    amount={editedLQTY.prettify()}
+                    maxAmount={maxAmount.toString()}
+                    maxedOut={maxedOut}
+                    unit={GT}
+                    {...{ editingState }}
+                    editedAmount={editedLQTY.toString(2)}
+                    setEditedAmount={newValue =>
+                        dispatch({ type: 'setStake', newValue })
+                    }
+                />
+                {newPoolShare.infinite ? (
+                    <StaticRow
+                        label='Pool share'
+                        inputID='stake-share'
+                        amount='N/A'
                     />
-                    {newPoolShare.infinite ? (
+                ) : (
+                    <StaticRow
+                        label='Pool share'
+                        inputID='stake-share'
+                        amount={newPoolShare.prettify(4)}
+                        pendingAmount={poolShareChange?.prettify(4).concat('%')}
+                        pendingColor={
+                            poolShareChange?.positive ? 'success' : 'danger'
+                        }
+                        unit='%'
+                    />
+                )}
+                {!originalStake.isEmpty && (
+                    <>
                         <StaticRow
-                            label='Pool share'
-                            inputID='stake-share'
-                            amount='N/A'
-                        />
-                    ) : (
-                        <StaticRow
-                            label='Pool share'
-                            inputID='stake-share'
-                            amount={newPoolShare.prettify(4)}
-                            pendingAmount={poolShareChange
-                                ?.prettify(4)
-                                .concat('%')}
-                            pendingColor={
-                                poolShareChange?.positive ? 'success' : 'danger'
+                            label='Redemption gain'
+                            inputID='stake-gain-eth'
+                            amount={originalStake.collateralGain.prettify(4)}
+                            color={
+                                originalStake.collateralGain.nonZero &&
+                                'success'
                             }
-                            unit='%'
+                            unit='ETH'
                         />
-                    )}
-                    {!originalStake.isEmpty && (
-                        <>
-                            <StaticRow
-                                label='Redemption gain'
-                                inputID='stake-gain-eth'
-                                amount={originalStake.collateralGain.prettify(
-                                    4
-                                )}
-                                color={
-                                    originalStake.collateralGain.nonZero &&
-                                    'success'
-                                }
-                                unit='ETH'
-                            />
 
-                            <StaticRow
-                                label='Issuance gain'
-                                inputID='stake-gain-lusd'
-                                amount={originalStake.lusdGain.prettify()}
-                                color={
-                                    originalStake.lusdGain.nonZero && 'success'
-                                }
-                                unit={COIN}
-                            />
-                        </>
-                    )}
-                    {children}
-                </Box>
-                {changePending && <LoadingOverlay />}
+                        <StaticRow
+                            label='Issuance gain'
+                            inputID='stake-gain-lusd'
+                            amount={originalStake.lusdGain.prettify()}
+                            color={originalStake.lusdGain.nonZero && 'success'}
+                            unit={COIN}
+                        />
+                    </>
+                )}
+                {children}
             </Box>
-        </Flex>
+            {changePending && <LoadingOverlay />}
+        </CardBase>
     )
 }

--- a/src/components/Trove/Adjusting.tsx
+++ b/src/components/Trove/Adjusting.tsx
@@ -24,6 +24,7 @@ import {
     ExpensiveTroveChangeWarning,
     GasEstimationState,
 } from './ExpensiveTroveChangeWarning'
+import { CardBase } from '../Layout/CardBase'
 import {
     selectForTroveChangeValidation,
     validateTroveChange,
@@ -202,185 +203,155 @@ export const Adjusting: React.FC = () => {
     }
 
     return (
-        <Flex
-            w='555px'
-            height='622px'
-            alignItems='center'
-            justifyContent='center'
-        >
-            <Box
-                w='100%'
-                h='100%'
-                maxW='md'
-                borderRadius='31px'
-                overflow='hidden'
-                padding={[10, 34, 34, 5]}
-                bg='#131313'
-                color='#FFFFFF'
-            >
-                <Heading>
-                    Trove
-                    {isDirty && !isTransactionPending && (
-                        <Button
-                            variant='titleIcon'
-                            sx={{ ':enabled:hover': { color: 'danger' } }}
-                            onClick={reset}
+        <CardBase>
+            <Heading>
+                Trove
+                {isDirty && !isTransactionPending && (
+                    <Button
+                        variant='titleIcon'
+                        sx={{ ':enabled:hover': { color: 'danger' } }}
+                        onClick={reset}
+                    >
+                        <Icon name='history' size='lg' />
+                    </Button>
+                )}
+            </Heading>
+
+            <Box>
+                <EditableRow
+                    label='Collateral'
+                    inputID='trove-collateral'
+                    amount={collateral.prettify(4)}
+                    maxAmount={maxCollateral.toString()}
+                    maxedOut={collateralMaxedOut}
+                    editingState={editingState}
+                    unit='ETH'
+                    editedAmount={collateral.toString(4)}
+                    setEditedAmount={(amount: string) =>
+                        setCollateral(Decimal.from(amount))
+                    }
+                />
+
+                <EditableRow
+                    label='Net debt'
+                    inputID='trove-net-debt-amount'
+                    amount={netDebt.prettify()}
+                    unit={'LUSD'}
+                    editingState={editingState}
+                    editedAmount={netDebt.toString(2)}
+                    setEditedAmount={(amount: string) =>
+                        setNetDebt(Decimal.from(amount))
+                    }
+                />
+
+                <StaticRow
+                    label='Liquidation Reserve'
+                    inputID='trove-liquidation-reserve'
+                    amount={`${LUSD_LIQUIDATION_RESERVE}`}
+                    unit={'LUSD'}
+                    infoIcon={
+                        <InfoIcon
+                            tooltip={
+                                <Box variant='tooltip' sx={{ width: '200px' }}>
+                                    An amount set aside to cover the
+                                    liquidator’s gas costs if your Trove needs
+                                    to be liquidated. The amount increases your
+                                    debt and is refunded if you close your Trove
+                                    by fully paying off its net debt.
+                                </Box>
+                            }
+                        />
+                    }
+                />
+
+                <StaticRow
+                    label='Borrowing Fee'
+                    inputID='trove-borrowing-fee'
+                    amount={fee.prettify(2)}
+                    pendingAmount={feePct.toString(2)}
+                    unit={'LUSD'}
+                    infoIcon={
+                        <InfoIcon
+                            tooltip={
+                                <Box variant='tooltip' sx={{ width: '240px' }}>
+                                    This amount is deducted from the borrowed
+                                    amount as a one-time fee. There are no
+                                    recurring fees for borrowing, which is thus
+                                    interest-free.
+                                </Box>
+                            }
+                        />
+                    }
+                />
+
+                <StaticRow
+                    label='Total debt'
+                    inputID='trove-total-debt'
+                    amount={totalDebt.prettify(2)}
+                    unit={'LUSD'}
+                    infoIcon={
+                        <InfoIcon
+                            tooltip={
+                                <Box variant='tooltip' sx={{ width: '240px' }}>
+                                    The total amount of LUSD your Trove will
+                                    hold.{' '}
+                                    {isDirty && (
+                                        <>
+                                            You will need to repay{' '}
+                                            {totalDebt
+                                                .sub(LUSD_LIQUIDATION_RESERVE)
+                                                .prettify(2)}{' '}
+                                            LUSD to reclaim your collateral (
+                                            {LUSD_LIQUIDATION_RESERVE.toString()}{' '}
+                                            LUSD Liquidation Reserve excluded).
+                                        </>
+                                    )}
+                                </Box>
+                            }
+                        />
+                    }
+                />
+
+                <CollateralRatio
+                    value={collateralRatio}
+                    change={collateralRatioChange}
+                />
+
+                {description ?? (
+                    <ActionDescription>
+                        Adjust your Trove by modifying its collateral, debt, or
+                        both.
+                    </ActionDescription>
+                )}
+
+                <ExpensiveTroveChangeWarning
+                    troveChange={stableTroveChange}
+                    maxBorrowingRate={maxBorrowingRate}
+                    borrowingFeeDecayToleranceMinutes={60}
+                    gasEstimationState={gasEstimationState}
+                    setGasEstimationState={setGasEstimationState}
+                />
+
+                <Flex variant='layout.actions'>
+                    <Button variant='cancel' onClick={handleCancelPressed}>
+                        Cancel
+                    </Button>
+
+                    {stableTroveChange ? (
+                        <TroveAction
+                            transactionId={TRANSACTION_ID}
+                            change={stableTroveChange}
+                            maxBorrowingRate={maxBorrowingRate}
+                            borrowingFeeDecayToleranceMinutes={60}
                         >
-                            <Icon name='history' size='lg' />
-                        </Button>
+                            Confirm
+                        </TroveAction>
+                    ) : (
+                        <Button disabled>Confirm</Button>
                     )}
-                </Heading>
-
-                <Box>
-                    <EditableRow
-                        label='Collateral'
-                        inputID='trove-collateral'
-                        amount={collateral.prettify(4)}
-                        maxAmount={maxCollateral.toString()}
-                        maxedOut={collateralMaxedOut}
-                        editingState={editingState}
-                        unit='ETH'
-                        editedAmount={collateral.toString(4)}
-                        setEditedAmount={(amount: string) =>
-                            setCollateral(Decimal.from(amount))
-                        }
-                    />
-
-                    <EditableRow
-                        label='Net debt'
-                        inputID='trove-net-debt-amount'
-                        amount={netDebt.prettify()}
-                        unit={'LUSD'}
-                        editingState={editingState}
-                        editedAmount={netDebt.toString(2)}
-                        setEditedAmount={(amount: string) =>
-                            setNetDebt(Decimal.from(amount))
-                        }
-                    />
-
-                    <StaticRow
-                        label='Liquidation Reserve'
-                        inputID='trove-liquidation-reserve'
-                        amount={`${LUSD_LIQUIDATION_RESERVE}`}
-                        unit={'LUSD'}
-                        infoIcon={
-                            <InfoIcon
-                                tooltip={
-                                    <Box
-                                        variant='tooltip'
-                                        sx={{ width: '200px' }}
-                                    >
-                                        An amount set aside to cover the
-                                        liquidator’s gas costs if your Trove
-                                        needs to be liquidated. The amount
-                                        increases your debt and is refunded if
-                                        you close your Trove by fully paying off
-                                        its net debt.
-                                    </Box>
-                                }
-                            />
-                        }
-                    />
-
-                    <StaticRow
-                        label='Borrowing Fee'
-                        inputID='trove-borrowing-fee'
-                        amount={fee.prettify(2)}
-                        pendingAmount={feePct.toString(2)}
-                        unit={'LUSD'}
-                        infoIcon={
-                            <InfoIcon
-                                tooltip={
-                                    <Box
-                                        variant='tooltip'
-                                        sx={{ width: '240px' }}
-                                    >
-                                        This amount is deducted from the
-                                        borrowed amount as a one-time fee. There
-                                        are no recurring fees for borrowing,
-                                        which is thus interest-free.
-                                    </Box>
-                                }
-                            />
-                        }
-                    />
-
-                    <StaticRow
-                        label='Total debt'
-                        inputID='trove-total-debt'
-                        amount={totalDebt.prettify(2)}
-                        unit={'LUSD'}
-                        infoIcon={
-                            <InfoIcon
-                                tooltip={
-                                    <Box
-                                        variant='tooltip'
-                                        sx={{ width: '240px' }}
-                                    >
-                                        The total amount of LUSD your Trove will
-                                        hold.{' '}
-                                        {isDirty && (
-                                            <>
-                                                You will need to repay{' '}
-                                                {totalDebt
-                                                    .sub(
-                                                        LUSD_LIQUIDATION_RESERVE
-                                                    )
-                                                    .prettify(2)}{' '}
-                                                LUSD to reclaim your collateral
-                                                (
-                                                {LUSD_LIQUIDATION_RESERVE.toString()}{' '}
-                                                LUSD Liquidation Reserve
-                                                excluded).
-                                            </>
-                                        )}
-                                    </Box>
-                                }
-                            />
-                        }
-                    />
-
-                    <CollateralRatio
-                        value={collateralRatio}
-                        change={collateralRatioChange}
-                    />
-
-                    {description ?? (
-                        <ActionDescription>
-                            Adjust your Trove by modifying its collateral, debt,
-                            or both.
-                        </ActionDescription>
-                    )}
-
-                    <ExpensiveTroveChangeWarning
-                        troveChange={stableTroveChange}
-                        maxBorrowingRate={maxBorrowingRate}
-                        borrowingFeeDecayToleranceMinutes={60}
-                        gasEstimationState={gasEstimationState}
-                        setGasEstimationState={setGasEstimationState}
-                    />
-
-                    <Flex variant='layout.actions'>
-                        <Button variant='cancel' onClick={handleCancelPressed}>
-                            Cancel
-                        </Button>
-
-                        {stableTroveChange ? (
-                            <TroveAction
-                                transactionId={TRANSACTION_ID}
-                                change={stableTroveChange}
-                                maxBorrowingRate={maxBorrowingRate}
-                                borrowingFeeDecayToleranceMinutes={60}
-                            >
-                                Confirm
-                            </TroveAction>
-                        ) : (
-                            <Button disabled>Confirm</Button>
-                        )}
-                    </Flex>
-                </Box>
-                {isTransactionPending && <LoadingOverlay />}
+                </Flex>
             </Box>
-        </Flex>
+            {isTransactionPending && <LoadingOverlay />}
+        </CardBase>
     )
 }

--- a/src/components/Trove/Editor.tsx
+++ b/src/components/Trove/Editor.tsx
@@ -19,7 +19,7 @@ export const Row: React.FC<RowProps> = ({
     infoIcon,
 }) => {
     return (
-        <Flex sx={{ alignItems: 'stretch', ...sx }}>
+        <Flex sx={{ alignItems: 'stretch', ...sx }} position='relative'>
             <FormLabel
                 id={labelId}
                 htmlFor={labelFor}
@@ -235,6 +235,7 @@ export const EditableRow: React.FC<EditableRowProps> = ({
                 borderRadius: '10px',
                 marginBottom: '16px',
                 height: '70px',
+                position: 'relative',
             }}
         >
             <Input

--- a/src/components/Trove/LiquidatedTrove.tsx
+++ b/src/components/Trove/LiquidatedTrove.tsx
@@ -5,6 +5,7 @@ import { LiquityStoreState } from '@liquity/lib-base'
 import { useLiquitySelector } from '../../hooks/useLiquitySelector'
 import { useTroveView } from './context/TroveViewContext'
 import { InfoMessage } from '../InfoMessage'
+import { CardBase } from 'components/Layout/CardBase'
 
 const select = ({ collateralSurplusBalance }: LiquityStoreState) => ({
     hasSurplusCollateral: !collateralSurplusBalance.isZero,
@@ -19,7 +20,7 @@ export const LiquidatedTrove: React.FC = () => {
     }, [dispatchEvent])
 
     return (
-        <Container>
+        <CardBase>
             <Heading>Trove</Heading>
             <Box sx={{ p: [2, 3] }}>
                 <InfoMessage title='Your Trove has been liquidated.'>
@@ -35,6 +36,6 @@ export const LiquidatedTrove: React.FC = () => {
                     )}
                 </Flex>
             </Box>
-        </Container>
+        </CardBase>
     )
 }

--- a/src/components/Trove/NoTrove.tsx
+++ b/src/components/Trove/NoTrove.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react'
 import { Heading, Box, Flex, Button } from '@chakra-ui/react'
 import { InfoMessage } from '../InfoMessage'
 import { useTroveView } from './context/TroveViewContext'
+import { CardBase } from 'components/Layout/CardBase'
 
 export const NoTrove: React.FC = props => {
     const { dispatchEvent } = useTroveView()
@@ -11,33 +12,17 @@ export const NoTrove: React.FC = props => {
     }, [dispatchEvent])
 
     return (
-        <Flex
-            w='555px'
-            height='432px'
-            alignItems='center'
-            justifyContent='center'
-        >
-            <Box
-                w='100%'
-                h='100%'
-                maxW='md'
-                borderWidth={1}
-                borderRadius='31px'
-                overflow='hidden'
-                bg='#131313'
-                color='#FFFFFF'
-            >
-                <Heading>Trove</Heading>
-                <Box sx={{ p: [2, 3] }}>
-                    <InfoMessage title="You haven't borrowed any LUSD yet.">
-                        You can borrow LUSD by opening a Trove.
-                    </InfoMessage>
+        <CardBase>
+            <Heading>Trove</Heading>
+            <Box sx={{ p: [2, 3] }}>
+                <InfoMessage title="You haven't borrowed any LUSD yet.">
+                    You can borrow LUSD by opening a Trove.
+                </InfoMessage>
 
-                    <Flex variant='layout.actions'>
-                        <Button onClick={handleOpenTrove}>Open Trove</Button>
-                    </Flex>
-                </Box>
+                <Flex variant='layout.actions'>
+                    <Button onClick={handleOpenTrove}>Open Trove</Button>
+                </Flex>
             </Box>
-        </Flex>
+        </CardBase>
     )
 }

--- a/src/components/Trove/Opening.tsx
+++ b/src/components/Trove/Opening.tsx
@@ -28,6 +28,7 @@ import {
     selectForTroveChangeValidation,
     validateTroveChange,
 } from './validation/validateTroveChange'
+import { CardBase } from 'components/Layout/CardBase'
 
 const selector = (state: LiquityStoreState) => {
     const { fees, price, accountBalance } = state
@@ -93,232 +94,208 @@ export const Opening: React.FC = () => {
     }, [collateral, borrowAmount])
     //will need to address hard-coded width for mobile
     return (
-        <Flex
-            w='555px'
-            height='622px'
-            alignItems='center'
-            justifyContent='center'
-        >
-            <Box
-                w='100%'
-                h='100%'
-                maxW='md'
-                borderRadius='31px'
-                overflow='hidden'
-                padding={[10, 34, 34, 5]}
-                bg='#131313'
-                color='#FFFFFF'
-            >
-                <Heading>
-                    Trove
-                    {isDirty && !isTransactionPending && (
-                        <Button
-                            variant='titleIcon'
-                            sx={{ ':enabled:hover': { color: 'danger' } }}
-                            onClick={reset}
+        <CardBase>
+            <Heading>
+                Trove
+                {isDirty && !isTransactionPending && (
+                    <Button
+                        variant='titleIcon'
+                        sx={{ ':enabled:hover': { color: 'danger' } }}
+                        onClick={reset}
+                    >
+                        <Icon name='history' size='lg' />
+                    </Button>
+                )}
+            </Heading>
+
+            <Box w='full'>
+                <EditableRow
+                    label='Collateral'
+                    inputID='trove-collateral'
+                    amount={collateral.prettify(4)}
+                    maxAmount={maxCollateral.toString()}
+                    maxedOut={collateralMaxedOut}
+                    editingState={editingState}
+                    unit='ETH'
+                    editedAmount={collateral.toString(4)}
+                    setEditedAmount={(amount: string) =>
+                        setCollateral(Decimal.from(amount))
+                    }
+                />
+
+                <EditableRow
+                    label='Borrow'
+                    inputID='trove-borrow-amount'
+                    amount={borrowAmount.prettify()}
+                    unit={'LUSD'}
+                    editingState={editingState}
+                    editedAmount={borrowAmount.toString(2)}
+                    setEditedAmount={(amount: string) =>
+                        setBorrowAmount(Decimal.from(amount))
+                    }
+                />
+
+                <StaticRow
+                    label='Liquidation Reserve'
+                    inputID='trove-liquidation-reserve'
+                    amount={`${LUSD_LIQUIDATION_RESERVE}`}
+                    unit={'LUSD'}
+                    infoIcon={
+                        <InfoIcon
+                            tooltip={
+                                <Box
+                                    borderWidth='1px'
+                                    borderRadius='md'
+                                    borderColor='#aaa'
+                                    overflow='hidden'
+                                    sx={{
+                                        padding: '10px',
+                                        bg: '#a7a7e3',
+                                        fontSize: '1em',
+                                        color: '#333',
+                                        minW: '12.5vw',
+                                        height: 'auto',
+                                        maxW: '33vm',
+                                        fontStyle: 'italic',
+                                    }}
+                                    md={{}}
+                                    lg={{}}
+                                >
+                                    An amount set aside to cover the
+                                    liquidator’s gas costs if your Trove needs
+                                    to be liquidated. The amount increases your
+                                    debt and is refunded if you close your Trove
+                                    by fully paying off its net debt.
+                                </Box>
+                            }
+                        />
+                    }
+                />
+
+                <StaticRow
+                    label='Borrowing Fee'
+                    inputID='trove-borrowing-fee'
+                    amount={fee.prettify(2)}
+                    pendingAmount={feePct.toString(2)}
+                    unit={'LUSD'}
+                    infoIcon={
+                        <InfoIcon
+                            tooltip={
+                                <Box
+                                    borderWidth='1px'
+                                    borderRadius='md'
+                                    borderColor='#aaa'
+                                    overflow='hidden'
+                                    sx={{
+                                        padding: '10px',
+                                        bg: '#a7a7e3',
+                                        fontSize: '1em',
+                                        color: '#333',
+                                        minW: '12.5vw',
+                                        height: 'auto',
+                                        maxW: '33vm',
+                                        fontStyle: 'italic',
+                                    }}
+                                    md={{}}
+                                    lg={{}}
+                                >
+                                    This amount is deducted from the borrowed
+                                    amount as a one-time fee. There are no
+                                    recurring fees for borrowing, which is thus
+                                    interest-free.
+                                </Box>
+                            }
+                        />
+                    }
+                />
+
+                <StaticRow
+                    label='Total debt'
+                    inputID='trove-total-debt'
+                    amount={totalDebt.prettify(2)}
+                    unit={'LUSD'}
+                    infoIcon={
+                        <InfoIcon
+                            placement='right'
+                            tooltip={
+                                <Box
+                                    borderWidth='1px'
+                                    borderRadius='md'
+                                    borderColor='#aaa'
+                                    overflow='hidden'
+                                    sx={{
+                                        padding: '10px',
+                                        bg: '#a7a7e3',
+                                        fontSize: '1em',
+                                        color: '#333',
+                                        minW: '12.5vw',
+                                        height: 'auto',
+                                        maxW: '33vm',
+                                        fontStyle: 'italic',
+                                    }}
+                                    md={{}}
+                                    lg={{}}
+                                >
+                                    The total amount of LUSD your Trove will
+                                    hold.{' '}
+                                    {isDirty && (
+                                        <>
+                                            You will need to repay{' '}
+                                            {totalDebt
+                                                .sub(LUSD_LIQUIDATION_RESERVE)
+                                                .prettify(2)}{' '}
+                                            LUSD to reclaim your collateral (
+                                            {LUSD_LIQUIDATION_RESERVE.toString()}{' '}
+                                            LUSD Liquidation Reserve excluded).
+                                        </>
+                                    )}
+                                </Box>
+                            }
+                        />
+                    }
+                />
+
+                <CollateralRatio value={collateralRatio} />
+
+                {description ?? (
+                    <ActionDescription>
+                        Start by entering the amount of ETH you&apos;d like to
+                        deposit as collateral.
+                    </ActionDescription>
+                )}
+
+                <ExpensiveTroveChangeWarning
+                    troveChange={stableTroveChange}
+                    maxBorrowingRate={maxBorrowingRate}
+                    borrowingFeeDecayToleranceMinutes={60}
+                    gasEstimationState={gasEstimationState}
+                    setGasEstimationState={setGasEstimationState}
+                />
+
+                <Flex variant='layout.actions'>
+                    <Button variant='cancel' onClick={handleCancelPressed}>
+                        Cancel
+                    </Button>
+
+                    {gasEstimationState.type === 'inProgress' ? (
+                        <Button disabled>
+                            <Spinner size='md' sx={{ color: 'background' }} />
+                        </Button>
+                    ) : stableTroveChange ? (
+                        <TroveAction
+                            transactionId={TRANSACTION_ID}
+                            change={stableTroveChange}
+                            maxBorrowingRate={maxBorrowingRate}
+                            borrowingFeeDecayToleranceMinutes={60}
                         >
-                            <Icon name='history' size='lg' />
-                        </Button>
+                            Confirm
+                        </TroveAction>
+                    ) : (
+                        <Button disabled>Confirm</Button>
                     )}
-                </Heading>
-
-                <Box w='full'>
-                    <EditableRow
-                        label='Collateral'
-                        inputID='trove-collateral'
-                        amount={collateral.prettify(4)}
-                        maxAmount={maxCollateral.toString()}
-                        maxedOut={collateralMaxedOut}
-                        editingState={editingState}
-                        unit='ETH'
-                        editedAmount={collateral.toString(4)}
-                        setEditedAmount={(amount: string) =>
-                            setCollateral(Decimal.from(amount))
-                        }
-                    />
-
-                    <EditableRow
-                        label='Borrow'
-                        inputID='trove-borrow-amount'
-                        amount={borrowAmount.prettify()}
-                        unit={'LUSD'}
-                        editingState={editingState}
-                        editedAmount={borrowAmount.toString(2)}
-                        setEditedAmount={(amount: string) =>
-                            setBorrowAmount(Decimal.from(amount))
-                        }
-                    />
-
-                    <StaticRow
-                        label='Liquidation Reserve'
-                        inputID='trove-liquidation-reserve'
-                        amount={`${LUSD_LIQUIDATION_RESERVE}`}
-                        unit={'LUSD'}
-                        infoIcon={
-                            <InfoIcon
-                                tooltip={
-                                    <Box
-                                        borderWidth='1px'
-                                        borderRadius='md'
-                                        borderColor='#aaa'
-                                        overflow='hidden'
-                                        sx={{
-                                            padding: '10px',
-                                            bg: '#a7a7e3',
-                                            fontSize: '1em',
-                                            color: '#333',
-                                            minW: '12.5vw',
-                                            height: 'auto',
-                                            maxW: '33vm',
-                                            fontStyle: 'italic',
-                                        }}
-                                        md={{}}
-                                        lg={{}}
-                                    >
-                                        An amount set aside to cover the
-                                        liquidator’s gas costs if your Trove
-                                        needs to be liquidated. The amount
-                                        increases your debt and is refunded if
-                                        you close your Trove by fully paying off
-                                        its net debt.
-                                    </Box>
-                                }
-                            />
-                        }
-                    />
-
-                    <StaticRow
-                        label='Borrowing Fee'
-                        inputID='trove-borrowing-fee'
-                        amount={fee.prettify(2)}
-                        pendingAmount={feePct.toString(2)}
-                        unit={'LUSD'}
-                        infoIcon={
-                            <InfoIcon
-                                tooltip={
-                                    <Box
-                                        borderWidth='1px'
-                                        borderRadius='md'
-                                        borderColor='#aaa'
-                                        overflow='hidden'
-                                        sx={{
-                                            padding: '10px',
-                                            bg: '#a7a7e3',
-                                            fontSize: '1em',
-                                            color: '#333',
-                                            minW: '12.5vw',
-                                            height: 'auto',
-                                            maxW: '33vm',
-                                            fontStyle: 'italic',
-                                        }}
-                                        md={{}}
-                                        lg={{}}
-                                    >
-                                        This amount is deducted from the
-                                        borrowed amount as a one-time fee. There
-                                        are no recurring fees for borrowing,
-                                        which is thus interest-free.
-                                    </Box>
-                                }
-                            />
-                        }
-                    />
-
-                    <StaticRow
-                        label='Total debt'
-                        inputID='trove-total-debt'
-                        amount={totalDebt.prettify(2)}
-                        unit={'LUSD'}
-                        infoIcon={
-                            <InfoIcon
-                                placement='right'
-                                tooltip={
-                                    <Box
-                                        borderWidth='1px'
-                                        borderRadius='md'
-                                        borderColor='#aaa'
-                                        overflow='hidden'
-                                        sx={{
-                                            padding: '10px',
-                                            bg: '#a7a7e3',
-                                            fontSize: '1em',
-                                            color: '#333',
-                                            minW: '12.5vw',
-                                            height: 'auto',
-                                            maxW: '33vm',
-                                            fontStyle: 'italic',
-                                        }}
-                                        md={{}}
-                                        lg={{}}
-                                    >
-                                        The total amount of LUSD your Trove will
-                                        hold.{' '}
-                                        {isDirty && (
-                                            <>
-                                                You will need to repay{' '}
-                                                {totalDebt
-                                                    .sub(
-                                                        LUSD_LIQUIDATION_RESERVE
-                                                    )
-                                                    .prettify(2)}{' '}
-                                                LUSD to reclaim your collateral
-                                                (
-                                                {LUSD_LIQUIDATION_RESERVE.toString()}{' '}
-                                                LUSD Liquidation Reserve
-                                                excluded).
-                                            </>
-                                        )}
-                                    </Box>
-                                }
-                            />
-                        }
-                    />
-
-                    <CollateralRatio value={collateralRatio} />
-
-                    {description ?? (
-                        <ActionDescription>
-                            Start by entering the amount of ETH you&apos;d like
-                            to deposit as collateral.
-                        </ActionDescription>
-                    )}
-
-                    <ExpensiveTroveChangeWarning
-                        troveChange={stableTroveChange}
-                        maxBorrowingRate={maxBorrowingRate}
-                        borrowingFeeDecayToleranceMinutes={60}
-                        gasEstimationState={gasEstimationState}
-                        setGasEstimationState={setGasEstimationState}
-                    />
-
-                    <Flex variant='layout.actions'>
-                        <Button variant='cancel' onClick={handleCancelPressed}>
-                            Cancel
-                        </Button>
-
-                        {gasEstimationState.type === 'inProgress' ? (
-                            <Button disabled>
-                                <Spinner
-                                    size='md'
-                                    sx={{ color: 'background' }}
-                                />
-                            </Button>
-                        ) : stableTroveChange ? (
-                            <TroveAction
-                                transactionId={TRANSACTION_ID}
-                                change={stableTroveChange}
-                                maxBorrowingRate={maxBorrowingRate}
-                                borrowingFeeDecayToleranceMinutes={60}
-                            >
-                                Confirm
-                            </TroveAction>
-                        ) : (
-                            <Button disabled>Confirm</Button>
-                        )}
-                    </Flex>
-                </Box>
-                {isTransactionPending && <LoadingOverlay />}
+                </Flex>
             </Box>
-        </Flex>
+            {isTransactionPending && <LoadingOverlay />}
+        </CardBase>
     )
 }

--- a/src/components/Trove/ReadOnlyTrove.tsx
+++ b/src/components/Trove/ReadOnlyTrove.tsx
@@ -23,7 +23,7 @@ export const ReadOnlyTrove: React.FC = () => {
     return (
         <CardBase>
             <Heading>Trove</Heading>
-            <Box overflow='hidden'>
+            <Box overflow='hidden' m={0}>
                 <Box>
                     <DisabledEditableRow
                         label='Collateral'

--- a/src/components/Trove/ReadOnlyTrove.tsx
+++ b/src/components/Trove/ReadOnlyTrove.tsx
@@ -6,6 +6,7 @@ import { DisabledEditableRow } from './Editor'
 import { useTroveView } from './context/TroveViewContext'
 import { Icon } from '../Icon'
 import { CollateralRatio } from './CollateralRatio'
+import { CardBase } from '../Layout/CardBase'
 
 const select = ({ trove, price }: LiquityStoreState) => ({ trove, price })
 
@@ -20,53 +21,37 @@ export const ReadOnlyTrove: React.FC = () => {
     const { trove, price } = useLiquitySelector(select)
 
     return (
-        <Flex
-            w='555px'
-            minHeight='418px'
-            alignItems='center'
-            justifyContent='center'
-        >
-            <Box
-                w='100%'
-                h='100%'
-                maxW='md'
-                borderRadius='31px'
-                overflow='hidden'
-                padding={[10, 34, 34, 5]}
-                bg='#131313'
-                color='#FFFFFF'
-            >
-                <Heading>Trove</Heading>
+        <CardBase>
+            <Heading>Trove</Heading>
+            <Box overflow='hidden' h='500px'>
                 <Box>
-                    <Box>
-                        <DisabledEditableRow
-                            label='Collateral'
-                            inputID='trove-collateral'
-                            amount={trove.collateral.prettify(4)}
-                            unit='ETH'
-                        />
+                    <DisabledEditableRow
+                        label='Collateral'
+                        inputID='trove-collateral'
+                        amount={trove.collateral.prettify(4)}
+                        unit='ETH'
+                    />
 
-                        <DisabledEditableRow
-                            label='Debt'
-                            inputID='trove-debt'
-                            amount={trove.debt.prettify()}
-                            unit={'LUSD'}
-                        />
+                    <DisabledEditableRow
+                        label='Debt'
+                        inputID='trove-debt'
+                        amount={trove.debt.prettify()}
+                        unit={'LUSD'}
+                    />
 
-                        <CollateralRatio value={trove.collateralRatio(price)} />
-                    </Box>
-
-                    <Flex variant='layout.actions'>
-                        <Button variant='outline' onClick={handleCloseTrove}>
-                            Close Trove
-                        </Button>
-                        <Button onClick={handleAdjustTrove}>
-                            <Icon name='pen' size='sm' />
-                            &nbsp;Adjust
-                        </Button>
-                    </Flex>
+                    <CollateralRatio value={trove.collateralRatio(price)} />
                 </Box>
+
+                <Flex variant='layout.actions'>
+                    <Button variant='outline' onClick={handleCloseTrove}>
+                        Close Trove
+                    </Button>
+                    <Button onClick={handleAdjustTrove}>
+                        <Icon name='pen' size='sm' />
+                        &nbsp;Adjust
+                    </Button>
+                </Flex>
             </Box>
-        </Flex>
+        </CardBase>
     )
 }

--- a/src/components/Trove/ReadOnlyTrove.tsx
+++ b/src/components/Trove/ReadOnlyTrove.tsx
@@ -23,7 +23,7 @@ export const ReadOnlyTrove: React.FC = () => {
     return (
         <CardBase>
             <Heading>Trove</Heading>
-            <Box overflow='hidden' h='500px'>
+            <Box overflow='hidden'>
                 <Box>
                     <DisabledEditableRow
                         label='Collateral'

--- a/src/components/Trove/RedeemedTrove.tsx
+++ b/src/components/Trove/RedeemedTrove.tsx
@@ -5,6 +5,7 @@ import { LiquityStoreState } from '@liquity/lib-base'
 import { useLiquitySelector } from '../../hooks/useLiquitySelector'
 import { useTroveView } from './context/TroveViewContext'
 import { InfoMessage } from '../InfoMessage'
+import { CardBase } from 'components/Layout/CardBase'
 
 const select = ({ collateralSurplusBalance }: LiquityStoreState) => ({
     hasSurplusCollateral: !collateralSurplusBalance.isZero,
@@ -19,7 +20,7 @@ export const RedeemedTrove: React.FC = () => {
     }, [dispatchEvent])
 
     return (
-        <Container>
+        <CardBase>
             <Heading>Trove</Heading>
             <Box sx={{ p: [2, 3] }}>
                 <InfoMessage title='Your Trove has been redeemed.'>
@@ -35,6 +36,6 @@ export const RedeemedTrove: React.FC = () => {
                     )}
                 </Flex>
             </Box>
-        </Container>
+        </CardBase>
     )
 }

--- a/src/components/Trove/TroveEditor.tsx
+++ b/src/components/Trove/TroveEditor.tsx
@@ -16,6 +16,7 @@ import { StaticRow } from './Editor'
 import { LoadingOverlay } from '../LoadingOverlay'
 import { CollateralRatio } from './CollateralRatio'
 import { InfoIcon } from '../InfoIcon'
+import { CardBase } from '../Layout/CardBase'
 
 type TroveEditorProps = {
     original: Trove
@@ -56,7 +57,7 @@ export const TroveEditor: React.FC<TroveEditorProps> = ({
     )
 
     return (
-        <Container>
+        <CardBase>
             <Heading>Trove</Heading>
 
             <Box sx={{ p: [2, 3] }}>
@@ -133,6 +134,6 @@ export const TroveEditor: React.FC<TroveEditorProps> = ({
             </Box>
 
             {changePending && <LoadingOverlay />}
-        </Container>
+        </CardBase>
     )
 }

--- a/src/components/utils/useWindowSize.tsx
+++ b/src/components/utils/useWindowSize.tsx
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react'
+
+function getWindowSize() {
+    const { innerWidth: width, innerHeight: height } = window
+    return {
+        width,
+        height,
+    }
+}
+
+export function useWindowSize() {
+    const [windowDimensions, setWindowDimensions] = useState(getWindowSize())
+
+    useEffect(() => {
+        function handleResize() {
+            setWindowDimensions(getWindowSize())
+        }
+
+        window.addEventListener('resize', handleResize)
+        return () => window.removeEventListener('resize', handleResize)
+    }, [])
+
+    return windowDimensions
+}

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -2,13 +2,7 @@ import { Grid, Box } from '@chakra-ui/react'
 import { Trove } from '../components/Trove/Trove'
 
 const Dashboard = (): JSX.Element => {
-    return (
-        <Grid display='flex' flexDirection={{ base: 'column', lg: 'row' }}>
-            <Box>
-                <Trove />
-            </Box>
-        </Grid>
-    )
+    return <Trove />
 }
 
 export default Dashboard

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,11 @@
 import React from 'react'
-import { VStack, Container } from '@chakra-ui/react'
 import { Wallet } from '@ethersproject/wallet'
 import { Decimal, Difference, Trove } from '@liquity/lib-base'
 import { LiquityStoreProvider } from '../components/LiquityStoreProvider'
 import { useLiquity } from '../hooks/LiquityContext'
 import { TransactionMonitor } from '../components/Transaction'
 import { SystemStatsPopup } from '../components/SystemStatsPopup'
+import { VStackBase } from '../components/Layout/VStackBase'
 import Dashboard from './dashboard'
 
 import { TroveViewProvider } from '../components/Trove/context/TroveViewProvider'
@@ -30,10 +30,10 @@ const LiquityFrontend = ({ loader }: LiquityFrontendProps): JSX.Element => {
     return (
         <LiquityStoreProvider {...{ loader }} store={liquity.store}>
             <TroveViewProvider>
-                <VStack maxHeight='662px' overflow='hidden' flex='1'>
+                <VStackBase>
                     <SystemStatsPopup />
                     <Dashboard />
-                </VStack>
+                </VStackBase>
             </TroveViewProvider>
             <TransactionMonitor />
         </LiquityStoreProvider>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Flex, Container } from '@chakra-ui/react'
+import { VStack, Container } from '@chakra-ui/react'
 import { Wallet } from '@ethersproject/wallet'
 import { Decimal, Difference, Trove } from '@liquity/lib-base'
 import { LiquityStoreProvider } from '../components/LiquityStoreProvider'
@@ -30,27 +30,10 @@ const LiquityFrontend = ({ loader }: LiquityFrontendProps): JSX.Element => {
     return (
         <LiquityStoreProvider {...{ loader }} store={liquity.store}>
             <TroveViewProvider>
-                <Flex
-                    sx={{
-                        flexDirection: 'column',
-                        minHeight: '100%',
-                        height: '100vh',
-                    }}
-                >
+                <VStack height='100vh' overflow='hidden'>
                     <SystemStatsPopup />
-
-                    <Container
-                        sx={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                            alignItems: 'center',
-                            width: '100vw',
-                            maxWidth: '912px',
-                        }}
-                    >
-                        <Dashboard />
-                    </Container>
-                </Flex>
+                    <Dashboard />
+                </VStack>
             </TroveViewProvider>
             <TransactionMonitor />
         </LiquityStoreProvider>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,7 +30,7 @@ const LiquityFrontend = ({ loader }: LiquityFrontendProps): JSX.Element => {
     return (
         <LiquityStoreProvider {...{ loader }} store={liquity.store}>
             <TroveViewProvider>
-                <VStack height='100vh' overflow='hidden'>
+                <VStack maxHeight='662px' overflow='hidden' flex='1'>
                     <SystemStatsPopup />
                     <Dashboard />
                 </VStack>

--- a/src/pages/pool.tsx
+++ b/src/pages/pool.tsx
@@ -1,10 +1,11 @@
-import { Grid, Box, Flex } from '@chakra-ui/react'
+import { Grid, Box, Flex, VStack } from '@chakra-ui/react'
 import { Wallet } from '@ethersproject/wallet'
 import { Decimal, Difference, Trove } from '@liquity/lib-base'
 import { useLiquity } from '../hooks/LiquityContext'
 import { Stability } from '../components/Stability/Stability'
 import { StabilityViewProvider } from '../components/Stability/context/StabilityViewProvider'
 import { LiquityStoreProvider } from 'components/LiquityStoreProvider'
+import { VStackBase } from 'components/Layout/VStackBase'
 
 type LiquityFrontendProps = {
     loader?: React.ReactNode
@@ -26,7 +27,9 @@ const Pool = ({ loader }: LiquityFrontendProps): JSX.Element => {
     return (
         <LiquityStoreProvider {...{ loader }} store={liquity.store}>
             <StabilityViewProvider>
-                <Stability />
+                <VStackBase>
+                    <Stability />
+                </VStackBase>
             </StabilityViewProvider>
         </LiquityStoreProvider>
     )

--- a/src/pages/pool.tsx
+++ b/src/pages/pool.tsx
@@ -26,17 +26,7 @@ const Pool = ({ loader }: LiquityFrontendProps): JSX.Element => {
     return (
         <LiquityStoreProvider {...{ loader }} store={liquity.store}>
             <StabilityViewProvider>
-                <Grid display='flex' justifyContent='center' bg='#363636'>
-                    <Flex
-                        sx={{
-                            flexDirection: 'column',
-                            minHeight: '100%',
-                            height: '100vh',
-                        }}
-                    >
-                        <Stability />
-                    </Flex>
-                </Grid>
+                <Stability />
             </StabilityViewProvider>
         </LiquityStoreProvider>
     )

--- a/src/pages/stake.tsx
+++ b/src/pages/stake.tsx
@@ -1,4 +1,4 @@
-import { Flex, Grid, Box } from '@chakra-ui/react'
+import { Flex, Grid, Box, VStack } from '@chakra-ui/react'
 import { Wallet } from '@ethersproject/wallet'
 import { Decimal, Difference, Trove } from '@liquity/lib-base'
 import { useLiquity } from '../hooks/LiquityContext'
@@ -26,19 +26,7 @@ const Stake = ({ loader }: LiquityFrontendProps): JSX.Element => {
     return (
         <LiquityStoreProvider {...{ loader }} store={liquity.store}>
             <StakingViewProvider>
-                <Grid display='flex' justifyContent='center' bg='#363636'>
-                    <Flex
-                        sx={{
-                            flexDirection: 'column',
-                            minHeight: '100%',
-                            height: 'fit-content',
-                        }}
-                    >
-                        <Box minWidth='504px'>
-                            <Staking />
-                        </Box>
-                    </Flex>
-                </Grid>
+                <Staking />
             </StakingViewProvider>
         </LiquityStoreProvider>
     )

--- a/src/pages/stake.tsx
+++ b/src/pages/stake.tsx
@@ -5,6 +5,7 @@ import { useLiquity } from '../hooks/LiquityContext'
 import { Staking } from '../components/Staking/Staking'
 import { StakingViewProvider } from '../components/Staking/context/StakingViewProvider'
 import { LiquityStoreProvider } from 'components/LiquityStoreProvider'
+import { VStackBase } from 'components/Layout/VStackBase'
 
 type LiquityFrontendProps = {
     loader?: React.ReactNode
@@ -26,7 +27,9 @@ const Stake = ({ loader }: LiquityFrontendProps): JSX.Element => {
     return (
         <LiquityStoreProvider {...{ loader }} store={liquity.store}>
             <StakingViewProvider>
-                <Staking />
+                <VStackBase>
+                    <Staking />
+                </VStackBase>
             </StakingViewProvider>
         </LiquityStoreProvider>
     )


### PR DESCRIPTION
Yoooooo

Summary:
- A ton of responsiveness features
- Biggest thing was abstracting the card and vstack into separate components
- Those abstractions let me really dial in the responsiveness and tweak it to an inch of it's life
- On mobile I added an inner scroll on the cards. Not sure about it, but it looks ok

Unfortunately I couldn't test all of the views because I didn't have token etc.

Get ready for screenshot overload! 

# Trove 

Trove views (ticked were tested): 
* [x] ACTIVE
* [x] ADJUSTING
* [x] CLOSING
* [ ] OPENING
* [ ] LIQUIDATED
* [ ] REDEEMED
* [ ] NONE

## Active

Desktop 
![Screenshot from 2022-03-24 00-49-42](https://user-images.githubusercontent.com/101533082/159820742-1e4aeb7a-8e24-418e-ac05-10e9dece97cc.png)

Mobile
![Screenshot from 2022-03-24 00-50-09](https://user-images.githubusercontent.com/101533082/159820794-b0591d34-6d90-4df3-a13f-0669b0a84c67.png)

## ADJUSTING

Desktop
![Screenshot from 2022-03-24 00-49-53](https://user-images.githubusercontent.com/101533082/159820876-d5fe7455-c838-4e2b-b854-1a0af9c8ce39.png)

Mobile
![Screenshot from 2022-03-24 00-50-29](https://user-images.githubusercontent.com/101533082/159820916-cf039baa-13a6-49d2-85d8-a3471cdcadaf.png)

## Closing

Desktop
![Screenshot from 2022-03-24 00-50-52](https://user-images.githubusercontent.com/101533082/159821030-9faf1000-1248-4998-9cdb-01b264a2cb63.png)

Mobile
![Screenshot from 2022-03-24 00-51-05](https://user-images.githubusercontent.com/101533082/159821055-60860930-5193-4d30-adcc-2de68b085eac.png)

# Stability

Stability views (ticked were tested): 
* [ ] NONE
* [ ] DEPOSITING
* [x] ADJUSTING
* [x] ACTIVE

## ACTIVE

Desktop
![Screenshot from 2022-03-24 00-59-33](https://user-images.githubusercontent.com/101533082/159821283-9bab552d-a4a1-4fa8-ad0c-83d02b3dd72a.png)

Mobile
![Screenshot from 2022-03-24 00-59-44](https://user-images.githubusercontent.com/101533082/159821333-83cc1ea7-3d77-4fa9-aa05-d40914818a77.png)

## ADJUSTING

Desktop 
![Screenshot from 2022-03-24 01-02-21](https://user-images.githubusercontent.com/101533082/159821429-2d6c4d13-b585-4efc-b30b-050eabff5d42.png)

Mobile
![Screenshot from 2022-03-24 01-02-37](https://user-images.githubusercontent.com/101533082/159821446-12119570-4867-4916-9c54-e7dc6838c500.png)

# Stake 

Stake views (ticked were tested): 
* [ ] ACTIVE
* [x] ADJUSTING
* [x] NONE

## NONE 

Desktop
![Screenshot from 2022-03-24 01-04-46](https://user-images.githubusercontent.com/101533082/159821613-9beb8135-b4d9-4e4e-9899-246b11743ee7.png)


Mobile
![Screenshot from 2022-03-24 01-05-02](https://user-images.githubusercontent.com/101533082/159821632-1691f7bd-06bd-4582-9153-e77aca5e68a5.png)

## ADJUSTING

Desktop
![Screenshot from 2022-03-24 01-06-24](https://user-images.githubusercontent.com/101533082/159821748-550ca2d8-2c3a-44a9-816a-91c0387f9d4e.png)


Mobile
![Screenshot from 2022-03-24 01-06-35](https://user-images.githubusercontent.com/101533082/159821771-63eb7460-2f50-412c-99d3-28558e379d77.png)


