### PR TITLE
Feature/button theme

### DIFF
--- a/src/components/Stability/ActiveDeposit.tsx
+++ b/src/components/Stability/ActiveDeposit.tsx
@@ -137,7 +137,7 @@ export const ActiveDeposit: React.FC = () => {
                 </Box>
 
                 <Flex variant='layout.actions'>
-                    <Button variant='outline' onClick={handleAdjustDeposit}>
+                    <Button variant='darkGrey' onClick={handleAdjustDeposit}>
                         <Icon name='pen' size='sm' />
                         &nbsp;Adjust
                     </Button>

--- a/src/components/Stability/NoDeposit.tsx
+++ b/src/components/Stability/NoDeposit.tsx
@@ -36,7 +36,11 @@ export const NoDeposit: React.FC = () => {
                     >
                         <Yield />
                     </Flex>
-                    <Button onClick={handleOpenTrove}>Deposit</Button>
+                </Flex>
+                <Flex>
+                    <Button variant='mainPurple' onClick={handleOpenTrove}>
+                        Deposit
+                    </Button>
                 </Flex>
             </Box>
         </CardBase>

--- a/src/components/Stability/StabilityDepositAction.tsx
+++ b/src/components/Stability/StabilityDepositAction.tsx
@@ -41,5 +41,9 @@ export const StabilityDepositAction: React.FC<StabilityDepositActionProps> = ({
               )
     )
 
-    return <Button onClick={sendTransaction}>{children}</Button>
+    return (
+        <Button variant='mainPurple' onClick={sendTransaction}>
+            {children}
+        </Button>
+    )
 }

--- a/src/components/Stability/StabilityDepositManager.tsx
+++ b/src/components/Stability/StabilityDepositManager.tsx
@@ -163,7 +163,9 @@ export const StabilityDepositManager: React.FC = () => {
                         Confirm
                     </StabilityDepositAction>
                 ) : (
-                    <Button disabled>Confirm</Button>
+                    <Button variant='darkPurple' disabled>
+                        Confirm
+                    </Button>
                 )}
             </Flex>
         </StabilityDepositEditor>

--- a/src/components/Staking/NoStake.tsx
+++ b/src/components/Staking/NoStake.tsx
@@ -16,6 +16,7 @@ export const NoStake: React.FC = () => {
                 </InfoMessage>
                 <Flex variant='layout.actions'>
                     <Button
+                        variant='mainPurple'
                         onClick={() => dispatch({ type: 'startAdjusting' })}
                     >
                         Start staking

--- a/src/components/Staking/ReadOnlyStake.tsx
+++ b/src/components/Staking/ReadOnlyStake.tsx
@@ -55,7 +55,7 @@ export const ReadOnlyStake: React.FC = () => {
 
                 <Flex variant='layout.actions'>
                     <Button
-                        variant='outline'
+                        variant='darkGrey'
                         onClick={() => dispatch({ type: 'startAdjusting' })}
                     >
                         <Icon name='pen' size='sm' />

--- a/src/components/Staking/StakingGainsAction.tsx
+++ b/src/components/Staking/StakingGainsAction.tsx
@@ -16,6 +16,7 @@ export const StakingGainsAction: React.FC = () => {
     )
     return (
         <Button
+            variant='darkPurple'
             onClick={sendTransaction}
             disabled={collateralGain.isZero && lusdGain.isZero}
         >

--- a/src/components/Staking/StakingManager.tsx
+++ b/src/components/Staking/StakingManager.tsx
@@ -172,7 +172,7 @@ export const StakingManager: React.FC = () => {
 
             <Flex variant='layout.actions'>
                 <Button
-                    variant='cancel'
+                    variant='darkGrey'
                     onClick={() =>
                         dispatchStakingViewAction({ type: 'cancelAdjusting' })
                     }
@@ -184,7 +184,9 @@ export const StakingManager: React.FC = () => {
                         Confirm
                     </StakingManagerAction>
                 ) : (
-                    <Button disabled>Confirm</Button>
+                    <Button variant='darkPurple' disabled>
+                        Confirm
+                    </Button>
                 )}
             </Flex>
         </StakingEditor>

--- a/src/components/Staking/StakingManagerAction.tsx
+++ b/src/components/Staking/StakingManagerAction.tsx
@@ -20,5 +20,9 @@ export const StakingManagerAction: React.FC<StakingActionProps> = ({
             : liquity.send.unstakeLQTY.bind(liquity.send, change.unstakeLQTY)
     )
 
-    return <Button onClick={sendTransaction}>{children}</Button>
+    return (
+        <Button variant='mainPurple' onClick={sendTransaction}>
+            {children}
+        </Button>
+    )
 }

--- a/src/components/Trove/Adjusting.tsx
+++ b/src/components/Trove/Adjusting.tsx
@@ -333,7 +333,7 @@ export const Adjusting: React.FC = () => {
                 />
 
                 <Flex variant='layout.actions'>
-                    <Button variant='cancel' onClick={handleCancelPressed}>
+                    <Button variant='darkGrey' onClick={handleCancelPressed}>
                         Cancel
                     </Button>
 
@@ -347,7 +347,9 @@ export const Adjusting: React.FC = () => {
                             Confirm
                         </TroveAction>
                     ) : (
-                        <Button disabled>Confirm</Button>
+                        <Button variant='mainPurple' disabled>
+                            Confirm
+                        </Button>
                     )}
                 </Flex>
             </Box>

--- a/src/components/Trove/Editor.tsx
+++ b/src/components/Trove/Editor.tsx
@@ -290,13 +290,7 @@ export const EditableRow: React.FC<EditableRowProps> = ({
             >
                 {maxAmount && (
                     <Button
-                        sx={{
-                            fontSize: '22px',
-                            padding: 1,
-                            paddingX: 3,
-                            height: '40px',
-                            marginBottom: '10px',
-                        }}
+                        variant='max'
                         onClick={event => {
                             setEditedAmount(maxAmount)
                             event.stopPropagation()

--- a/src/components/Trove/LiquidatedTrove.tsx
+++ b/src/components/Trove/LiquidatedTrove.tsx
@@ -32,7 +32,9 @@ export const LiquidatedTrove: React.FC = () => {
                 <Flex variant='layout.actions'>
                     {hasSurplusCollateral && <CollateralSurplusAction />}
                     {!hasSurplusCollateral && (
-                        <Button onClick={handleOpenTrove}>Open Trove</Button>
+                        <Button variant='mainPurple' onClick={handleOpenTrove}>
+                            Open Trove
+                        </Button>
                     )}
                 </Flex>
             </Box>

--- a/src/components/Trove/NoTrove.tsx
+++ b/src/components/Trove/NoTrove.tsx
@@ -20,7 +20,9 @@ export const NoTrove: React.FC = props => {
                 </InfoMessage>
 
                 <Flex variant='layout.actions'>
-                    <Button onClick={handleOpenTrove}>Open Trove</Button>
+                    <Button variant='mainPurple' onClick={handleOpenTrove}>
+                        Open Trove
+                    </Button>
                 </Flex>
             </Box>
         </CardBase>

--- a/src/components/Trove/Opening.tsx
+++ b/src/components/Trove/Opening.tsx
@@ -273,12 +273,12 @@ export const Opening: React.FC = () => {
                 />
 
                 <Flex variant='layout.actions'>
-                    <Button variant='cancel' onClick={handleCancelPressed}>
+                    <Button variant='darkGrey' onClick={handleCancelPressed}>
                         Cancel
                     </Button>
 
                     {gasEstimationState.type === 'inProgress' ? (
-                        <Button disabled>
+                        <Button variant='darkGrey' disabled>
                             <Spinner size='md' sx={{ color: 'background' }} />
                         </Button>
                     ) : stableTroveChange ? (

--- a/src/components/Trove/ReadOnlyTrove.tsx
+++ b/src/components/Trove/ReadOnlyTrove.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from 'react'
-import { Container, Heading, Box, Flex, Button } from '@chakra-ui/react'
+import { Container, Heading, Box, Flex, Button, Spacer } from '@chakra-ui/react'
 import { useLiquitySelector } from '../../hooks/useLiquitySelector'
 import { LiquityStoreState } from '@liquity/lib-base'
 import { DisabledEditableRow } from './Editor'
@@ -41,12 +41,11 @@ export const ReadOnlyTrove: React.FC = () => {
 
                     <CollateralRatio value={trove.collateralRatio(price)} />
                 </Box>
-
                 <Flex variant='layout.actions'>
-                    <Button variant='outline' onClick={handleCloseTrove}>
+                    <Button variant='darkGrey' onClick={handleCloseTrove}>
                         Close Trove
                     </Button>
-                    <Button onClick={handleAdjustTrove}>
+                    <Button variant='mainPurple' onClick={handleAdjustTrove}>
                         <Icon name='pen' size='sm' />
                         &nbsp;Adjust
                     </Button>

--- a/src/components/Trove/RedeemedTrove.tsx
+++ b/src/components/Trove/RedeemedTrove.tsx
@@ -32,7 +32,9 @@ export const RedeemedTrove: React.FC = () => {
                 <Flex variant='layout.actions'>
                     {hasSurplusCollateral && <CollateralSurplusAction />}
                     {!hasSurplusCollateral && (
-                        <Button onClick={handleOpenTrove}>Open Trove</Button>
+                        <Button variant='mainPurple' onClick={handleOpenTrove}>
+                            Open Trove
+                        </Button>
                     )}
                 </Flex>
             </Box>

--- a/src/components/Trove/TroveAction.tsx
+++ b/src/components/Trove/TroveAction.tsx
@@ -36,5 +36,9 @@ export const TroveAction: React.FC<TroveActionProps> = ({
               })
     )
 
-    return <Button onClick={sendTransaction}>{children}</Button>
+    return (
+        <Button variant='mainPurple' onClick={sendTransaction}>
+            {children}
+        </Button>
+    )
 }

--- a/src/components/Trove/TroveManager.tsx
+++ b/src/components/Trove/TroveManager.tsx
@@ -268,7 +268,7 @@ export const TroveManager: React.FC<TroveManagerProps> = ({
                 ))}
 
             <Flex variant='layout.actions'>
-                <Button variant='cancel' onClick={handleCancel}>
+                <Button variant='darkGrey' onClick={handleCancel}>
                     Cancel
                 </Button>
 
@@ -282,7 +282,9 @@ export const TroveManager: React.FC<TroveManagerProps> = ({
                         Confirm
                     </TroveAction>
                 ) : (
-                    <Button disabled>Confirm</Button>
+                    <Button variant='mainPurple' disabled>
+                        Confirm
+                    </Button>
                 )}
             </Flex>
         </TroveEditor>

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -6,9 +6,9 @@ const colors = {
     interactive: {
         dark: '#1E2230',
         dimmedBlue: '#4C5E9D',
-        purple: '#6257DE',
-        darkPurple: '#4234D0',
-        darkGrey: '#9393A1',
+        purple: '#6d29fe',
+        darkPurple: '#20113f',
+        darkGrey: '#2f2f2f',
         grey: '#CECECE',
         white: '#FFFFFF',
         transparentWhite: 'rgba(255, 255, 255, 0.35)',

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -76,6 +76,20 @@ const Button = {
             flex: '1',
             _hover: {
                 bg: 'interactive.grey',
+                // some views change color to black on hover, future bug will need fix
+                color: 'white',
+            },
+        },
+        max: {
+            bg: 'interactive.grey',
+            fontSize: '22px',
+            color: 'white',
+            py: 1,
+            px: 3,
+            height: '40px',
+            marginBottom: '10px',
+            _hover: {
+                bg: 'interactive.darkGrey',
                 color: '#000000',
             },
         },

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -1,79 +1,104 @@
 const Button = {
     baseStyle: {
-        fontWeight: "medium",
-        boxSizing: "border-box",
-        mx: "20px"
+        fontWeight: 'medium',
+        boxSizing: 'border-box',
+        mx: '.25em',
     },
     sizes: {
-        primary:{
+        primary: {
             px: {
-                base: "20px",
-                md: "28px",
-                lg: "51px",
+                base: '20px',
+                md: '28px',
+                lg: '51px',
             },
             py: {
-                base: "12px",
-                md: "14px",
-                lg: "23px"
+                base: '12px',
+                md: '14px',
+                lg: '23px',
             },
             borderRadius: {
-                base: "13px",
-                md: "13px",
-                lg: "24px",
+                base: '.15em',
+                md: '.15em',
+                lg: '.15em',
             },
             fontSize: {
-                base: "18px",
-                md: "18px",
-                lg: "24px"
+                base: '16px',
+                md: '18px',
+                lg: '20px',
             },
-            lineHeight: "22px"
+            lineHeight: '18px',
         },
         secondary: {
-            px: "20px",
-            py: "10px",
-            borderRadius: "13px",
-            fontSize: "1rem",
-            lineHeight: "1.225",
-        }
+            px: '20px',
+            py: '10px',
+            borderRadius: '13px',
+            fontSize: '1rem',
+            lineHeight: '1.225',
+        },
     },
-    variants: { // TODO: Relative units
+    variants: {
+        // TODO: Relative units
         solid: ({ onDark }: { onDark?: boolean }) => ({
-            bg: !onDark ? "interactive.dark": "none",
-            color: "interactive.white",
-            border: !onDark ? "none" : "2px solid",
-            borderColor: !onDark ? "rgba(0,0,0,0)": "interactive.purple",
+            bg: !onDark ? 'interactive.dark' : 'none',
+            color: 'interactive.white',
+            border: !onDark ? 'none' : '2px solid',
+            borderColor: !onDark ? 'rgba(0,0,0,0)' : 'interactive.purple',
             _hover: {
-                bg: "interactive.darkPurple"
+                bg: 'interactive.darkPurple',
             },
             _active: {
-                bg: !onDark ? "interactive.dark" : "interactive.darkPurple"
+                bg: !onDark ? 'interactive.dark' : 'interactive.darkPurple',
             },
             _disabled: {
-                bg: "interactive.gray",
-                color: "interactive.transparentWhite"
-            }
+                bg: 'interactive.gray',
+                color: 'interactive.transparentWhite',
+            },
         }),
-        outline: {
-            bg: "none",
-            color: "interactive.dark",
-            border: "2px solid",
+        mainPurple: {
+            bg: 'interactive.purple',
+            color: 'interactive.white',
+            flex: '1',
             _hover: {
-                bg: "interactive.darkPurple",
-                color: "interactive.white",
-                border: "2px solid",
-                borderColor: "rgba(0,0,0,0)"
+                bg: 'interactive.darkPurple',
+            },
+        },
+        darkPurple: {
+            bg: 'interactive.darkPurple',
+            color: 'interactive.white',
+            flex: '1',
+            _hover: {
+                bg: 'interactive.purple',
+            },
+        },
+        darkGrey: {
+            bg: 'interactive.darkGrey',
+            color: 'interactive.white',
+            flex: '1',
+            _hover: {
+                bg: 'interactive.grey',
+                color: '#000000',
+            },
+        },
+        outline: {
+            bg: 'none',
+            color: 'interactive.dark',
+            border: '2px solid',
+            _hover: {
+                bg: 'interactive.darkPurple',
+                color: 'interactive.white',
+                border: '2px solid',
+                borderColor: 'rgba(0,0,0,0)',
             },
             _active: {
-                bg: "interactive.dark",
+                bg: 'interactive.dark',
             },
             _disabled: {
-                bg: "interactive.gray",
-                color: "interactive.transparentWhite"
-            }
-        }
+                bg: 'interactive.gray',
+                color: 'interactive.transparentWhite',
+            },
+        },
     },
-    defaultProps: {}
+    defaultProps: {},
 }
 
-
-export default Button;
+export default Button

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -36,6 +36,7 @@ const customTheme = extendTheme({
         Section,
         Box,
         Container,
+        Button,
     },
     layerStyles: {
         baseStyle: {


### PR DESCRIPTION
Added base button theme variants.  Implemented the button variants in the Trove, Stability, and Stake views.  Left out the button in the heading of some of these cards and the Yield at Geositta's request.  

Card Layout will be fixed in a future PR