### PR TITLE
Feature/trove info boxes

### DIFF
--- a/src/components/ActionDescription.tsx
+++ b/src/components/ActionDescription.tsx
@@ -25,5 +25,7 @@ export const ActionDescription: React.FC = ({ children }) => (
 )
 
 export const Amount: React.FC = ({ children }) => (
-    <Text sx={{ fontWeight: 'bold', whiteSpace: 'nowrap' }}>{children}</Text>
+    <Text sx={{ fontSize: '24px', fontWeight: 'bold', whiteSpace: 'nowrap' }}>
+        {children}
+    </Text>
 )

--- a/src/components/ActionDescription.tsx
+++ b/src/components/ActionDescription.tsx
@@ -13,12 +13,12 @@ export const ActionDescription: React.FC = ({ children }) => (
             borderRadius: '8px',
             borderColor: 'accent',
             boxShadow: 2,
-            bg: 'rgba(46, 182, 234, 0.05)',
-            fontSize: '22px',
+            bg: '#222222',
+            fontSize: '18px',
         }}
     >
         <Flex sx={{ alignItems: 'center' }}>
-            <Icon name='info-circle' size='lg' />
+            <Icon name='info-circle' size='lg' color='#505050' />
             <Text sx={{ ml: 2 }}>{children}</Text>
         </Flex>
     </Box>

--- a/src/components/ErrorDescription.tsx
+++ b/src/components/ErrorDescription.tsx
@@ -15,11 +15,11 @@ export const ErrorDescription: React.FC = ({ children }) => (
             borderRadius: '8px',
             borderColor: 'danger',
             boxShadow: 2,
-            bg: 'rgba(220, 44, 16, 0.05)',
+            bg: '#370b0b',
         }}
     >
         <Flex sx={{ alignItems: 'center' }}>
-            <Icon name='exclamation-triangle' size='lg' />
+            <Icon name='exclamation-triangle' size='lg' color='#fee500' />
             <Text sx={{ ml: 2 }}>{children}</Text>
         </Flex>
     </Box>

--- a/src/components/ErrorDescription.tsx
+++ b/src/components/ErrorDescription.tsx
@@ -16,9 +16,10 @@ export const ErrorDescription: React.FC = ({ children }) => (
             borderColor: 'danger',
             boxShadow: 2,
             bg: '#370b0b',
+            fontSize: '18px',
         }}
     >
-        <Flex sx={{ alignItems: 'center' }}>
+        <Flex align='center' direction='row' wrap='wrap'>
             <Icon name='exclamation-triangle' size='lg' color='#fee500' />
             <Text sx={{ ml: 2 }}>{children}</Text>
         </Flex>


### PR DESCRIPTION
Updated the info box components for the Trove.  The info component, (ActionDescription) is used in other areas as well like Stability, but the color and sizes are the same.  

Error box in some places has 3 lines of text.  The only way to reliably make it 2 lines on smaller screens is to add if statements that will be strange.  Breakpoints won't work because the layout is determined by the characters inside the element. 