### PR TITLE
Add transaction feedback to card

### DIFF
--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -48,9 +48,9 @@ const LoadingFeedback = ({ type }: LoadingFeedbackProps) => {
         const messageCapitalised =
             messageWithSpaces.charAt(0).toUpperCase() +
             messageWithSpaces.slice(1)
-        const oddCases = ['cancelled', 'failed']
+        const specialCases = ['cancelled', 'failed', 'confirmed']
 
-        return oddCases.includes(type)
+        return specialCases.includes(type)
             ? `Transaction ${messageCapitalised}!`
             : messageCapitalised
     }
@@ -60,32 +60,31 @@ const LoadingFeedback = ({ type }: LoadingFeedbackProps) => {
         }
     }, [type])
     return (
-        <Container
-            variant='disabledOverlay'
-            p={0}
-            mt='32px'
-            size='16px'
-            style={{
-                display: 'flex',
-                justifyContent: 'start',
-                alignItems: 'center',
-            }}
-        >
+        <>
             {localType && localType !== 'idle' && (
-                <>
+                <Container
+                    variant='disabledOverlay'
+                    p={0}
+                    mt='32px'
+                    size='16px'
+                    style={{
+                        display: 'flex',
+                        justifyContent: 'start',
+                        alignItems: 'center',
+                    }}
+                >
                     <Spinner size='lg' color='text' />
                     <LoadingBadge type={localType} />
                     <Text ml='16px' px={0}>
                         {parseType(localType)}
                     </Text>
-                </>
+                </Container>
             )}
-        </Container>
+        </>
     )
 }
 
 export const LoadingOverlay: React.FC = () => {
     const [transactionState] = useTransactionState()
-    console.log('transaction St :', transactionState)
     return <LoadingFeedback type={transactionState.type} />
 }

--- a/src/components/LoadingOverlay.tsx
+++ b/src/components/LoadingOverlay.tsx
@@ -1,13 +1,91 @@
-import React from 'react'
-import { Container, Spinner } from '@chakra-ui/react'
+import React, { useEffect, useState } from 'react'
+import { Container, Spinner, Text, Badge } from '@chakra-ui/react'
+import { useTransactionState } from './Transaction'
 
-export const LoadingOverlay: React.FC = () => (
-    <Container
-        variant='disabledOverlay'
-        mt='32px'
-        size='16px'
-        style={{ display: 'flex', justifyContent: 'center' }}
-    >
-        <Spinner size='lg' color='text' />
-    </Container>
-)
+type LoadingBadgeProps = {
+    type: string
+}
+
+const LoadingBadge = ({ type }: LoadingBadgeProps) => {
+    switch (type) {
+        case 'waitingForApproval':
+        case 'waitingForConfirmation':
+            return (
+                <Badge ml='16px' colorScheme='purple'>
+                    Waiting
+                </Badge>
+            )
+        case 'failed':
+            return (
+                <Badge ml='16px' colorScheme='red'>
+                    Failed
+                </Badge>
+            )
+        case 'cancelled':
+            return (
+                <Badge ml='16px' colorScheme='orange'>
+                    Cancelled
+                </Badge>
+            )
+        default:
+            return (
+                <Badge ml='16px' colorScheme='teal'>
+                    Confirmed
+                </Badge>
+            )
+    }
+}
+
+type LoadingFeedbackProps = {
+    type: string
+}
+
+const LoadingFeedback = ({ type }: LoadingFeedbackProps) => {
+    const [localType, setLocalType] = useState<null | string>(null)
+    function parseType(type: string) {
+        // Message usually arrives as camelCase eg waitingForApproval
+        const messageWithSpaces = type.replace(/([a-z](?=[A-Z]))/g, '$1 ')
+        const messageCapitalised =
+            messageWithSpaces.charAt(0).toUpperCase() +
+            messageWithSpaces.slice(1)
+        const oddCases = ['cancelled', 'failed']
+
+        return oddCases.includes(type)
+            ? `Transaction ${messageCapitalised}!`
+            : messageCapitalised
+    }
+    useEffect(() => {
+        if (type) {
+            setLocalType(type)
+        }
+    }, [type])
+    return (
+        <Container
+            variant='disabledOverlay'
+            p={0}
+            mt='32px'
+            size='16px'
+            style={{
+                display: 'flex',
+                justifyContent: 'start',
+                alignItems: 'center',
+            }}
+        >
+            {localType && localType !== 'idle' && (
+                <>
+                    <Spinner size='lg' color='text' />
+                    <LoadingBadge type={localType} />
+                    <Text ml='16px' px={0}>
+                        {parseType(localType)}
+                    </Text>
+                </>
+            )}
+        </Container>
+    )
+}
+
+export const LoadingOverlay: React.FC = () => {
+    const [transactionState] = useTransactionState()
+    console.log('transaction St :', transactionState)
+    return <LoadingFeedback type={transactionState.type} />
+}

--- a/src/components/Stability/ActiveDeposit.tsx
+++ b/src/components/Stability/ActiveDeposit.tsx
@@ -113,7 +113,7 @@ export const ActiveDeposit: React.FC = () => {
                 </ClaimAndMove>
             )}
 
-            {isWaitingForTransaction && <LoadingOverlay />}
+            <LoadingOverlay />
         </CardBase>
     )
 }

--- a/src/components/Stability/StabilityDepositEditor.tsx
+++ b/src/components/Stability/StabilityDepositEditor.tsx
@@ -144,7 +144,7 @@ export const StabilityDepositEditor: React.FC<StabilityDepositEditorProps> = ({
                 {children}
             </Box>
 
-            {changePending && <LoadingOverlay />}
+            <LoadingOverlay />
         </CardBase>
     )
 }

--- a/src/components/Staking/ReadOnlyStake.tsx
+++ b/src/components/Staking/ReadOnlyStake.tsx
@@ -69,7 +69,7 @@ export const ReadOnlyStake: React.FC = () => {
                 <StakingGainsAction />
             </HStack>
 
-            {changePending && <LoadingOverlay />}
+            <LoadingOverlay />
         </CardBase>
     )
 }

--- a/src/components/Staking/StakingEditor.tsx
+++ b/src/components/Staking/StakingEditor.tsx
@@ -125,7 +125,7 @@ export const StakingEditor: React.FC<StakingEditorProps> = ({
                 )}
             </Box>
             {children}
-            {changePending && <LoadingOverlay />}
+            <LoadingOverlay />
         </CardBase>
     )
 }

--- a/src/components/Transaction.tsx
+++ b/src/components/Transaction.tsx
@@ -105,7 +105,7 @@ export const TransactionProvider: React.FC = ({ children }) => {
     )
 }
 
-const useTransactionState = () => {
+export const useTransactionState = () => {
     const transactionState = useContext(TransactionContext)
 
     if (!transactionState) {
@@ -449,38 +449,39 @@ export const TransactionMonitor: React.FC = () => {
     }
 
     return (
-        <Flex
-            sx={{
-                alignItems: 'center',
-                bg:
-                    transactionState.type === 'confirmed'
-                        ? '#20113f'
-                        : transactionState.type === 'cancelled'
-                        ? '#CECECE'
-                        : transactionState.type === 'failed'
-                        ? 'salmon'
-                        : '#4C5E9D',
-                p: 3,
-                pl: 4,
-                position: 'fixed',
-                width: '100vw',
-                bottom: 0,
-                overflow: 'hidden',
-            }}
-        >
-            <Box sx={{ mr: 3, width: '40px', height: '40px' }}>
-                <TransactionProgressDonut state={transactionState.type} />
-            </Box>
+        <></>
+        // <Flex
+        //     sx={{
+        //         alignItems: 'center',
+        //         bg:
+        //             transactionState.type === 'confirmed'
+        //                 ? '#20113f'
+        //                 : transactionState.type === 'cancelled'
+        //                 ? '#CECECE'
+        //                 : transactionState.type === 'failed'
+        //                 ? 'salmon'
+        //                 : '#4C5E9D',
+        //         p: 3,
+        //         pl: 4,
+        //         position: 'fixed',
+        //         width: '100vw',
+        //         bottom: 0,
+        //         overflow: 'hidden',
+        //     }}
+        // >
+        //     <Box sx={{ mr: 3, width: '40px', height: '40px' }}>
+        //         <TransactionProgressDonut state={transactionState.type} />
+        //     </Box>
 
-            <Text sx={{ fontSize: '20px', color: 'white' }}>
-                {transactionState.type === 'waitingForConfirmation'
-                    ? 'Waiting for confirmation'
-                    : transactionState.type === 'cancelled'
-                    ? 'Cancelled'
-                    : transactionState.type === 'failed'
-                    ? transactionState.error.message
-                    : 'Confirmed'}
-            </Text>
-        </Flex>
+        //     <Text sx={{ fontSize: '20px', color: 'white' }}>
+        //         {transactionState.type === 'waitingForConfirmation'
+        //             ? 'Waiting for confirmation'
+        //             : transactionState.type === 'cancelled'
+        //             ? 'Cancelled'
+        //             : transactionState.type === 'failed'
+        //             ? transactionState.error.message
+        //             : 'Confirmed'}
+        //     </Text>
+        // </Flex>
     )
 }

--- a/src/components/Trove/Adjusting.tsx
+++ b/src/components/Trove/Adjusting.tsx
@@ -333,7 +333,7 @@ export const Adjusting: React.FC = () => {
                     )}
                 </HStack>
             </Box>
-            {isTransactionPending && <LoadingOverlay />}
+            <LoadingOverlay />
         </CardBase>
     )
 }

--- a/src/components/Trove/Opening.tsx
+++ b/src/components/Trove/Opening.tsx
@@ -218,7 +218,7 @@ export const Opening: React.FC = () => {
                     )}
                 </HStack>
             </Box>
-            {isTransactionPending && <LoadingOverlay />}
+            <LoadingOverlay />
         </CardBase>
     )
 }

--- a/src/components/Trove/TroveEditor.tsx
+++ b/src/components/Trove/TroveEditor.tsx
@@ -101,7 +101,7 @@ export const TroveEditor: React.FC<TroveEditorProps> = ({
                 {children}
             </Box>
 
-            {changePending && <LoadingOverlay />}
+            <LoadingOverlay />
         </CardBase>
     )
 }


### PR DESCRIPTION
Closes #209

Add new functionality for showing transaction feedback on the card

- Cases handled:
  - idle: hides the loader 
  - failed: show Failed badge + 'Transaction Failed'
  - cancelled: shows Cancelled badge + 'Transaction Cancelled'
  - waitingForApproval: shows Waiting badge + 'Waiting For Approval'
  - waitingForConfirmation: shows Waiting badge + 'Waiting For Confirmation'
  - confirmed: shows Confirmed badge + 'Waiting For Approval'
  - confirmedOneShot
  
 # Screenshots
 
## Confirmed

> Message updated to 'Confirmed Transaction'

![desktop-confirmed](https://user-images.githubusercontent.com/101533082/169716107-2d5dcdb8-b919-4a3b-a2d1-c3f4fb04c9a8.png)
![mobile-confirmed](https://user-images.githubusercontent.com/101533082/169716110-b9f224f0-3dfe-499c-8d44-aa15ee52ba9f.png)

## Waiting For Confirmation

![mobile-waitingForConfirmation](https://user-images.githubusercontent.com/101533082/169716127-978a371d-6a97-4ee5-816d-0a38bd9c9428.png)
![desktop-waitingForConfirmation](https://user-images.githubusercontent.com/101533082/169716130-8313c027-3377-4b9c-88bd-fed651fe7596.png)

## Waiting For Approval

![desktop-waitingForApproval](https://user-images.githubusercontent.com/101533082/169716141-c12a5a12-cac9-464f-9042-70aaa63e54c9.png)
![mobile-waitingForApproval](https://user-images.githubusercontent.com/101533082/169716142-34c5fb60-5e7d-4cfe-92c7-06f604bda0ce.png)

## Failed 

![mobile-failed](https://user-images.githubusercontent.com/101533082/169716147-2788bcf2-04d5-4d3f-bc96-c8966d56f18f.png)
![desktop-failed](https://user-images.githubusercontent.com/101533082/169716148-f162e5e3-fe6a-4607-b192-463c09f25131.png)

## Cancelled

![desktop-cancelled](https://user-images.githubusercontent.com/101533082/169716160-21f66bb1-26cf-4fdf-908e-4deccdc30b9e.png)
![mobile-cancelled](https://user-images.githubusercontent.com/101533082/169716162-d9999f76-50dd-4a58-8918-be87b63b3897.png)
 